### PR TITLE
Use default values of a method if not actual value is provided

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,14 @@
+0.12.0
+- Use parameter default value if no value is provided on method call
+
 0.11.0
-- Adds support for responses from async methods.
+- Adds support for responses from async methods
 - Removed Utils Project
 - Improved Error Handling
 - Adjusted action handler to pass directly params instead of named params to comply with protocol
 
 0.10.0
-- Adds reference to the Utils project.
+- Adds reference to the Utils project
 
 0.9.0
 - Adds fix for concurrency 

--- a/Grenache.Test/src/RpcActionHandlerTests.cs
+++ b/Grenache.Test/src/RpcActionHandlerTests.cs
@@ -2,6 +2,7 @@ using System;
 using Grenache.Utils;
 using Xunit;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace Grenache.Test;
 
@@ -81,6 +82,47 @@ public class RpcActionHandlerTests
     // Assert
     Assert.ThrowsAny<JsonException>(() => _handler.HandleAction(json));
   }
+  
+  [Fact]
+  public async Task HandleAction_UsesDefaultParameterValues_WhenNoArgsProvided()
+  {
+    // Arrange
+    const string json = """
+                                {
+                                    "action": "TestMethodWithOptionalParam",
+                                    "args": [ "value1" ]
+                                }
+                        """;
+
+    // Act
+    var resultDelegate = _handler.HandleAction(json);
+    var testClassInstance = new TestClass();
+    var result = await resultDelegate(testClassInstance);
+
+    // Assert 
+    Assert.Equal(100, result);
+  }
+
+  [Fact]
+  public async Task HandleAction_DoesNotUseDefaultParameterValues_WhenArgsProvided()
+  {
+    // Arrange
+    const string json = """
+                                {
+                                    "action": "TestMethodWithOptionalParam",
+                                    "args": [ "value1", 7 ]
+                                }
+                        """;
+
+    // Act
+    var resultDelegate = _handler.HandleAction(json);
+    var testClassInstance = new TestClass();
+    var result = await resultDelegate(testClassInstance);
+
+    // Assert 
+    Assert.Equal(7, result);
+  }
+
 }
 
 public class TestClass
@@ -88,6 +130,12 @@ public class TestClass
   public void TestMethod(string param1, int param2)
   {
     Console.WriteLine($"TestMethod called with param1={param1} and param2={param2}");
+  }
+
+  public int TestMethodWithOptionalParam(string param1, int param2 = 100)
+  {
+    Console.WriteLine($"TestMethod called with param1={param1} and param2={param2}");
+    return param2;
   }
 
   public string Greet(string message)

--- a/Grenache/Grenache.csproj
+++ b/Grenache/Grenache.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Grenache</RootNamespace>
     <PackageId>Grenache</PackageId>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Authors>prdn, vigan.abd, kamil518</Authors>
     <Company>Bitfinex</Company>
     <Title>Grenache.NET</Title>

--- a/Grenache/src/Utils/RpcActionHandler.cs
+++ b/Grenache/src/Utils/RpcActionHandler.cs
@@ -167,6 +167,10 @@ public class RpcActionHandler(Type type)
           throw new ArgumentException($"ERR_MISSING_PARAMETER: Missing required parameter: {param.Name}");
         }
       }
+      else if (param.HasDefaultValue)
+      {
+        methodArgs[i] = param.DefaultValue;
+      }
     }
 
     return methodArgs;


### PR DESCRIPTION
These changes fix issue of default values of a method being ignored when no arguments are provided.

