### PR TITLE
Optionally accept JsonSerializerOptions to parse the response data

### DIFF
--- a/Grenache/src/Interfaces/IRPCClient.cs
+++ b/Grenache/src/Interfaces/IRPCClient.cs
@@ -9,13 +9,13 @@ public interface IRPCClient
   Task<RpcClientResponse> Request(string service, object payload);
   Task<RpcClientResponse[]> Map(string service, object payload);
 
-  static T ParseRpcResponseData<T>(RpcClientResponse response)
+  static T ParseRpcResponseData<T>(RpcClientResponse response, JsonSerializerOptions options = null)
   {
     if (typeof(T) == typeof(bool))
     {
       return (T)(object)bool.Parse(response.Data);
     }
 
-    return JsonSerializer.Deserialize<T>(response.Data);
+    return JsonSerializer.Deserialize<T>(response.Data, options);
   }
 }


### PR DESCRIPTION
This change will be useful for clients who need to parse strings to enums automatically when the `ParseRpcResponseData` method is called.